### PR TITLE
drop lix 2.92 and 2.93 repo builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.direnv/
 result
+result-man

--- a/nix/archives.nix
+++ b/nix/archives.nix
@@ -3,14 +3,10 @@
   callPackage,
   pkgs,
 
-  editline,
-  lixVersions,
-  ncurses,
+  lixPackageSets,
 }:
 
 let
-  pins = import ../npins;
-
   inherit (lib) listToAttrs nameValuePair replaceStrings;
 
   makeStoreArchive = callPackage ./make-store-archive.nix { };
@@ -33,28 +29,11 @@ let
   # Accepts a system, and returns a list of Lix derivations that are supported on that system.
   # Currently there's no variation between systems (ie. all systems support all versions), but that may change in the
   # future.
-  lixVersionsForSystem =
-    system:
-    let
-      # The Lix repo doesn't give us a good way to override nixpkgs when consuming it from outside a flake, so we can
-      # do some hacks with the overlay instead.
-      lix_2_92 = ((import pins.lix-2_92).overlays.default pkgs pkgs).nix.override {
-        # From <https://git.lix.systems/lix-project/nixos-module/pulls/59>:
-        # Do not override editline-lix
-        # according to the upstream packaging.
-        # This was fixed in nixpkgs directly.
-        editline-lix = editline.overrideAttrs (old: {
-          propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ ncurses ];
-        });
-      };
-
-      lix_2_93 = ((import pins.lix-2_93).overlays.default pkgs pkgs).nix;
-    in
-    [
-      lix_2_93
-      lix_2_92
-      lixVersions.lix_2_91
-    ];
+  lixVersionsForSystem = system: [
+    lixPackageSets.lix_2_93.lix
+    lixPackageSets.lix_2_92.lix
+    lixPackageSets.lix_2_91.lix
+  ];
 in
 rec {
   # Accepts a system, and returns an attribute set from supported versions to Lix derivations.

--- a/nix/archives.nix
+++ b/nix/archives.nix
@@ -27,13 +27,30 @@ let
     );
 
   # Accepts a system, and returns a list of Lix derivations that are supported on that system.
-  # Currently there's no variation between systems (ie. all systems support all versions), but that may change in the
-  # future.
-  lixVersionsForSystem = system: [
-    lixPackageSets.lix_2_93.lix
-    lixPackageSets.lix_2_92.lix
-    lixPackageSets.lix_2_91.lix
-  ];
+  lixVersionsForSystem =
+    system:
+    let
+      # enabling LTO on darwin systems seems to cause all manner of weird and wacky bustage on lix 2.92 and newer.
+      # until that's fixed, or until nixpkgs disables it there as well, this function will produce lix derivations that
+      # build with LTO disabled on darwin.
+      # https://github.com/NixOS/nixpkgs/pull/398141#discussion_r2091831651
+      # https://git.lix.systems/lix-project/lix/issues/832
+      disableLTO =
+        lix:
+        if !(builtins.elem system lib.platforms.darwin) then
+          lix
+        else
+          lix.overrideAttrs (prev: {
+            mesonFlags = (builtins.filter (flag: !(lib.hasInfix "b_lto" flag)) prev.mesonFlags) ++ [
+              (lib.mesonBool "b_lto" false)
+            ];
+          });
+    in
+    [
+      (disableLTO lixPackageSets.lix_2_93.lix)
+      (disableLTO lixPackageSets.lix_2_92.lix)
+      lixPackageSets.lix_2_91.lix
+    ];
 in
 rec {
   # Accepts a system, and returns an attribute set from supported versions to Lix derivations.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -37,8 +37,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre773343.1750f3c1c894/nixexprs.tar.xz",
-      "hash": "0wl2gcvybbmp88zd7555c7qr4zzi3hbwhb0zinn48hr22iflzg7r"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre801852.3fcbdcfc707e/nixexprs.tar.xz",
+      "hash": "1axizzdkrgzbd7wd3wjisafjnkgvyy8fhiv5zmp5zwi28n0jn0wi"
     }
   },
   "version": 5

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -1,39 +1,5 @@
 {
   "pins": {
-    "lix-2_92": {
-      "type": "GitRelease",
-      "repository": {
-        "type": "Forgejo",
-        "server": "https://git.lix.systems/",
-        "owner": "lix-project",
-        "repo": "lix"
-      },
-      "pre_releases": false,
-      "version_upper_bound": null,
-      "release_prefix": null,
-      "submodules": false,
-      "version": "2.92.0",
-      "revision": "2837da71ec1588c1187d2e554719b15904a46c8b",
-      "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2.92.0.tar.gz",
-      "hash": "126vm9m517gwfqdy1c4zghzk3w3xfahhhjawkqmkjxrq9w08h8h8"
-    },
-    "lix-2_93": {
-      "type": "GitRelease",
-      "repository": {
-        "type": "Forgejo",
-        "server": "https://git.lix.systems/",
-        "owner": "lix-project",
-        "repo": "lix"
-      },
-      "pre_releases": false,
-      "version_upper_bound": null,
-      "release_prefix": null,
-      "submodules": false,
-      "version": "2.93.0",
-      "revision": "47aad376c87e2e65967f17099277428e4b3f8e5a",
-      "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2.93.0.tar.gz",
-      "hash": "0g17i8yz5j0i2v29c2fddksvnc5n8fc5ml2pz0jhxaia7ghmxhc6"
-    },
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",


### PR DESCRIPTION
Now that NixOS/nixpkgs#393444 has landed in nixpkgs-unstable, we don't need to build Lix 2.92 from sources anymore.