### PR TITLE
add lix 2.93

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,9 +57,9 @@ jobs:
           - macos-15
           - macos-13
         version:
+          - 2.93.0
           - 2.92.0
           - 2.91.1
-          - 2.90.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -91,9 +91,9 @@ jobs:
           - macos-15
           - macos-13
         version:
+          - 2.93.0
           - 2.92.0
           - 2.91.1
-          - 2.90.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: canidae solutions
 inputs:
   lix_version:
     required: true
-    default: "2.92.0"
+    default: "2.93.0"
     description: |
       The version of Lix that should be installed.
 

--- a/nix/archives.nix
+++ b/nix/archives.nix
@@ -47,8 +47,11 @@ let
           propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ ncurses ];
         });
       };
+
+      lix_2_93 = ((import pins.lix-2_93).overlays.default pkgs pkgs).nix;
     in
     [
+      lix_2_93
       lix_2_92
       lixVersions.lix_2_91
       lixVersions.lix_2_90

--- a/nix/archives.nix
+++ b/nix/archives.nix
@@ -54,7 +54,6 @@ let
       lix_2_93
       lix_2_92
       lixVersions.lix_2_91
-      lixVersions.lix_2_90
     ];
 in
 rec {

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -17,6 +17,23 @@
       "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2.92.0.tar.gz",
       "hash": "126vm9m517gwfqdy1c4zghzk3w3xfahhhjawkqmkjxrq9w08h8h8"
     },
+    "lix-2_93": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "Forgejo",
+        "server": "https://git.lix.systems/",
+        "owner": "lix-project",
+        "repo": "lix"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "2.93.0",
+      "revision": "47aad376c87e2e65967f17099277428e4b3f8e5a",
+      "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/2.93.0.tar.gz",
+      "hash": "0g17i8yz5j0i2v29c2fddksvnc5n8fc5ml2pz0jhxaia7ghmxhc6"
+    },
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",


### PR DESCRIPTION
2.93 is now the default version. support for 2.90 is also dropped as a result of being older than the last 3 minor releases.