### PR TITLE
nixpkgs bump

### DIFF
--- a/nix/archives.nix
+++ b/nix/archives.nix
@@ -27,30 +27,13 @@ let
     );
 
   # Accepts a system, and returns a list of Lix derivations that are supported on that system.
-  lixVersionsForSystem =
-    system:
-    let
-      # enabling LTO on darwin systems seems to cause all manner of weird and wacky bustage on lix 2.92 and newer.
-      # until that's fixed, or until nixpkgs disables it there as well, this function will produce lix derivations that
-      # build with LTO disabled on darwin.
-      # https://github.com/NixOS/nixpkgs/pull/398141#discussion_r2091831651
-      # https://git.lix.systems/lix-project/lix/issues/832
-      disableLTO =
-        lix:
-        if !(builtins.elem system lib.platforms.darwin) then
-          lix
-        else
-          lix.overrideAttrs (prev: {
-            mesonFlags = (builtins.filter (flag: !(lib.hasInfix "b_lto" flag)) prev.mesonFlags) ++ [
-              (lib.mesonBool "b_lto" false)
-            ];
-          });
-    in
-    [
-      (disableLTO lixPackageSets.lix_2_93.lix)
-      (disableLTO lixPackageSets.lix_2_92.lix)
-      lixPackageSets.lix_2_91.lix
-    ];
+  # Currently there's no variation between systems (ie. all systems support all versions), but that may change in the
+  # future.
+  lixVersionsForSystem = system: [
+    lixPackageSets.lix_2_93.lix
+    lixPackageSets.lix_2_92.lix
+    lixPackageSets.lix_2_91.lix
+  ];
 in
 rec {
   # Accepts a system, and returns an attribute set from supported versions to Lix derivations.

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre801852.3fcbdcfc707e/nixexprs.tar.xz",
-      "hash": "1axizzdkrgzbd7wd3wjisafjnkgvyy8fhiv5zmp5zwi28n0jn0wi"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre804427.e314d5c6d3b3/nixexprs.tar.xz",
+      "hash": "1iqsppm554zzydqb5adnbv5i38paysvc8q6hyib58cp6z0ighnsi"
     }
   },
   "version": 5


### PR DESCRIPTION
also remove the LTO disable override, since that's now [included in nixpkgs](https://github.com/NixOS/nixpkgs/commit/ccd5688c946fb85e7125a6384b38f863361215a8).