### PR TITLE
update lix versions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -25,8 +25,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: canidae-solutions/lix-quick-install-action@v3
         with:
-          lix_archives_url: https://github.com/canidae-solutions/lix-quick-install-action/releases/download/v3.0.2
-          lix_version: 2.93.1
+          lix_archives_url: https://github.com/canidae-solutions/lix-quick-install-action/releases/download/v3.0.1
+          lix_version: 2.93.0
       - uses: cachix/cachix-action@v16
         with:
           name: canidae-solutions
@@ -57,9 +57,9 @@ jobs:
           - macos-15
           - macos-13
         version:
-          - 2.93.1
-          - 2.92.2
-          - 2.91.2
+          - 2.93.2
+          - 2.92.3
+          - 2.91.3
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -91,9 +91,9 @@ jobs:
           - macos-15
           - macos-13
         version:
-          - 2.93.1
-          - 2.92.2
-          - 2.91.2
+          - 2.93.2
+          - 2.92.3
+          - 2.91.3
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -152,7 +152,7 @@ jobs:
       - uses: ./
         with:
           lix_archives_url: file:///tmp/archives
-          lix_version: 2.93.1
+          lix_version: 2.93.2
       - uses: cachix/cachix-action@v16
         with:
           name: canidae-solutions

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: canidae solutions
 inputs:
   lix_version:
     required: true
-    default: "2.93.1"
+    default: "2.93.2"
     description: |
       The version of Lix that should be installed.
 

--- a/npins/sources.json
+++ b/npins/sources.json
@@ -3,8 +3,8 @@
     "nixpkgs": {
       "type": "Channel",
       "name": "nixpkgs-unstable",
-      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre821324.61c0f5139114/nixexprs.tar.xz",
-      "hash": "0iqqnyrnrf1avr92b8v2npdd7ckm67qqqabdd825rvfhh7wcxv4g"
+      "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre824823.c860cf0b3a08/nixexprs.tar.xz",
+      "hash": "1aj58xqv0km9zm9ldz72pwsisifvybp2h9qb0mwx98468v2qar73"
     }
   },
   "version": 5


### PR DESCRIPTION
- 2.93.1 -> 2.93.2
- 2.92.2 -> 2.92.3
- 2.91.2 -> 2.91.3

fixes https://lix.systems/blog/2025-06-27-lix-critical-bug/